### PR TITLE
Add build and release GitHub workflow for tagged commits

### DIFF
--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'ultravioletrs/cocos'
+        ref: ${{ github.ref }}
         path: cocos
 
     - name: Checkout buildroot

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+    branches: ["cocos-62"]
 
 jobs:
   build:

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '*'
-    branches: ["cocos-62"]
 
 jobs:
   build:

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout cocos
       uses: actions/checkout@v4
       with:
-        repository: 'ultravioletrs/cocos'
+        repository: 'sammyoina/cocos-ai'
         ref: ${{ github.ref }}
         path: cocos
 

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -15,6 +15,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get upgrade -y
+    
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21.x
+        cache-dependency-path: "go.sum"
 
     - name: Checkout cocos
       uses: actions/checkout@v4

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -1,0 +1,62 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout cocos
+      uses: actions/checkout@v2
+      with:
+        repository: 'ultravioletrs/cocos'
+        path: cocos
+
+    - name: Checkout buildroot
+      uses: actions/checkout@v2
+      with:
+        repository: 'buildroot/buildroot'
+        path: buildroot
+
+    - name: Build
+      run: |
+        cd buildroot
+        make BR2_EXTERNAL=../cocos/hal/linux cocos_defconfig
+        make
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-kernel
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./buildroot/output/images/bzImage
+        asset_name: bzImage
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release Asset
+      id: upload-release-rootfs
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./buildroot/output/images/rootfs.cpio.gz
+        asset_name: rootfs.cpio.gz
+        asset_content_type: application/gzip

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Update Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade -y
+
     - name: Checkout cocos
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
     - name: Checkout cocos
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'ultravioletrs/cocos'
         path: cocos
 
     - name: Checkout buildroot
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'buildroot/buildroot'
         path: buildroot
@@ -30,7 +30,7 @@ jobs:
 
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -41,7 +41,7 @@ jobs:
 
     - name: Upload Release Asset
       id: upload-release-kernel
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -52,7 +52,7 @@ jobs:
 
     - name: Upload Release Asset
       id: upload-release-rootfs
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/hal.yml
+++ b/.github/workflows/hal.yml
@@ -19,8 +19,7 @@ jobs:
     - name: Checkout cocos
       uses: actions/checkout@v4
       with:
-        repository: 'sammyoina/cocos-ai'
-        ref: ${{ github.ref }}
+        repository: 'ultravioletrs/cocos'
         path: cocos
 
     - name: Checkout buildroot

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ultravioletrs/cocos
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/absmach/magistrala v0.0.0-20240110171157-9f573850fc4b

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ultravioletrs/cocos
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/absmach/magistrala v0.0.0-20240110171157-9f573850fc4b

--- a/hal/linux/package/agent/agent.mk
+++ b/hal/linux/package/agent/agent.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-AGENT_VERSION = main
-AGENT_SITE = $(call github,ultravioletrs,cocos,$(AGENT_VERSION))
+AGENT_VERSION = cocos-62
+AGENT_SITE = $(call github,sammyoina,cocos-ai,$(AGENT_VERSION))
 
 define AGENT_BUILD_CMDS 	
 	$(MAKE) -C $(@D) agent

--- a/hal/linux/package/agent/agent.mk
+++ b/hal/linux/package/agent/agent.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-AGENT_VERSION = cocos-62
-AGENT_SITE = $(call github,sammyoina,cocos-ai,$(AGENT_VERSION))
+AGENT_VERSION = main
+AGENT_SITE = $(call github,ultravioletrs,cocos,$(AGENT_VERSION))
 
 define AGENT_BUILD_CMDS 	
 	$(MAKE) -C $(@D) agent


### PR DESCRIPTION
Introduced a new GitHub Actions workflow to automate building and releasing for tagged commits. The workflow checks out the required repositories, builds the project using Buildroot configurations, and creates a release with the resultant kernel and rootfs artifacts. This streamlines the release process, ensuring consistent and reproducible builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Build and Release" GitHub Actions workflow to automate building and releasing process for updates and new versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->